### PR TITLE
Specify more strict host permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,11 @@
   "name": "No Dumb TLDs",
   "version": "1.0",
   "description": "Prevents loading of webpages with Google's new .zip and .mov TLDs.",
-  "permissions": ["webRequest", "webRequestBlocking", "<all_urls>"],
+  "permissions": ["webRequest", "webRequestBlocking"],
+  "host_permissions": [
+    "*://*.zip/*",
+    "*://*.mov/*"
+  ]
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
Honestly not sure if this is 100%, but should get things in the right direction.

Documentation here:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions